### PR TITLE
BACK-6: Criar serviço para Projects

### DIFF
--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/application/services/ProjectService.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/application/services/ProjectService.java
@@ -1,0 +1,110 @@
+package br.com.edu.alunos.utfpr.protrack.application.services;
+
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Objects;
+
+import br.com.edu.alunos.utfpr.protrack.application.services.generic.GenericServiceImpl;
+import br.com.edu.alunos.utfpr.protrack.domain.dtos.project.CreateProjectDTO;
+import br.com.edu.alunos.utfpr.protrack.domain.dtos.project.UpdateProjectDTO;
+import br.com.edu.alunos.utfpr.protrack.domain.exceptions.FailedToCreateProjectException;
+import br.com.edu.alunos.utfpr.protrack.domain.exceptions.NotFoundException;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Client;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Project;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Team;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.ClientRepository;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.ProjectRepository;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.TeamRepository;
+
+@Service
+public class ProjectService extends GenericServiceImpl<Project, Long> {
+
+    private final ClientRepository clientRepository;
+    private final TeamRepository teamRepository;
+
+    public ProjectService(
+            final ProjectRepository projectRepository,
+            final ClientRepository clientRepository,
+            final TeamRepository teamRepository) {
+        super(projectRepository);
+        this.clientRepository = clientRepository;
+        this.teamRepository = teamRepository;
+    }
+
+    public Project create(final CreateProjectDTO dto) throws FailedToCreateProjectException {
+        try {
+            final Project project = new Project();
+            project.setName(dto.name());
+            project.setDescription(dto.description());
+            final Client client = clientRepository.findById(dto.clientId())
+                    .orElseThrow(() -> new NotFoundException(
+                            String.format("Client with id %d not found!", dto.clientId())));
+            final Team team = teamRepository.findById(dto.teamId())
+                    .orElseThrow(() -> new NotFoundException(
+                            String.format("Team with id %d not found!", dto.teamId())));
+            project.setClient(client);
+            project.setTeam(team);
+            project.setStartDate(dto.startDate());
+            project.setEndDate(dto.endDate());
+            return super.save(project);
+        } catch (final NotFoundException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new FailedToCreateProjectException();
+        }
+    }
+
+    public Project update(final UpdateProjectDTO dto) {
+        final Project project = super.findById(dto.id())
+                .orElseThrow(() -> new NotFoundException(
+                        String.format("Project with id %d not found!", dto.id())));
+
+        if (Objects.nonNull(dto.name())) {
+            project.setName(dto.name());
+        }
+        if (Objects.nonNull(dto.description())) {
+            project.setDescription(dto.description());
+        }
+        if (Objects.nonNull(dto.clientId())) {
+            final Client client = clientRepository.findById(dto.clientId())
+                    .orElseThrow(() -> new NotFoundException(
+                            String.format("Client with id %d not found!", dto.clientId())));
+            project.setClient(client);
+        }
+        if (Objects.nonNull(dto.teamId())) {
+            final Team team = teamRepository.findById(dto.teamId())
+                    .orElseThrow(() -> new NotFoundException(
+                            String.format("Team with id %d not found!", dto.teamId())));
+            project.setTeam(team);
+        }
+        if (Objects.nonNull(dto.startDate())) {
+            project.setStartDate(dto.startDate());
+        }
+        if (Objects.nonNull(dto.endDate())) {
+            project.setEndDate(dto.endDate());
+        }
+
+        return super.save(project);
+    }
+
+    public void delete(final Long id) {
+        super.findById(id)
+                .orElseThrow(() -> new NotFoundException(
+                        String.format("Project with id %d not found!", id)));
+        repository.deleteById(id);
+    }
+
+    public List<Project> getAll() {
+        try {
+            return super.findAll();
+        } catch (final Exception e) {
+            throw new RuntimeException("Failed to fetch projects", e);
+        }
+    }
+
+    public Project getById(final Long id) {
+        return super.findById(id)
+                .orElseThrow(() -> new NotFoundException(
+                        String.format("Project with id %d not found!", id)));
+    }
+}

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/dtos/project/CreateProjectDTO.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/dtos/project/CreateProjectDTO.java
@@ -1,0 +1,12 @@
+package br.com.edu.alunos.utfpr.protrack.domain.dtos.project;
+
+import java.time.LocalDate;
+
+public record CreateProjectDTO(
+    String name,
+    String description,
+    Long clientId,
+    Long teamId,
+    LocalDate startDate,
+    LocalDate endDate
+) { }

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/dtos/project/UpdateProjectDTO.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/dtos/project/UpdateProjectDTO.java
@@ -1,0 +1,12 @@
+package br.com.edu.alunos.utfpr.protrack.domain.dtos.project;
+import java.time.LocalDate;
+
+public record UpdateProjectDTO(
+    Long id,
+    String name,
+    String description,
+    Long clientId,
+    Long teamId,
+    LocalDate startDate,
+    LocalDate endDate
+) { }

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/exceptions/FailedToCreateProjectException.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/exceptions/FailedToCreateProjectException.java
@@ -1,0 +1,4 @@
+package br.com.edu.alunos.utfpr.protrack.domain.exceptions;
+
+public class FailedToCreateProjectException extends Throwable {
+}

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/exceptions/InvalidDateRangeException.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/exceptions/InvalidDateRangeException.java
@@ -1,0 +1,4 @@
+package br.com.edu.alunos.utfpr.protrack.domain.exceptions;
+
+public class InvalidDateRangeException extends Exception{
+}

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/models/Project.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/domain/models/Project.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import br.com.edu.alunos.utfpr.protrack.resources.responses.ProjectResponse;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -12,8 +13,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
 public class Project {
 
     @Id
@@ -43,6 +48,17 @@ public class Project {
         if (tasks.isEmpty()) return 0;
         final long finishedCount = tasks.stream().filter(Task::isFinished).count();
         return (int) ((double) finishedCount / tasks.size() * 100);
+    }
+
+    public ProjectResponse toResponse() {
+        final ProjectResponse response = new ProjectResponse();
+        response.setName(name);
+        response.setDescription(description);
+        response.setClientId(client.getId());
+        response.setTeamId(team.getId());
+        response.setStartDate(startDate);
+        response.setEndDate(endDate);
+        return response;
     }
 }
 

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/infrastructure/repositories/ClientRepository.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/infrastructure/repositories/ClientRepository.java
@@ -1,0 +1,8 @@
+package br.com.edu.alunos.utfpr.protrack.infrastructure.repositories;
+
+import br.com.edu.alunos.utfpr.protrack.domain.models.Client;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Employee;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.generic.GenericRepository;
+
+public interface ClientRepository extends GenericRepository<Client, Long> {
+}

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/infrastructure/repositories/ProjectRepository.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/infrastructure/repositories/ProjectRepository.java
@@ -1,0 +1,8 @@
+package br.com.edu.alunos.utfpr.protrack.infrastructure.repositories;
+
+import br.com.edu.alunos.utfpr.protrack.domain.models.Employee;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Project;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.generic.GenericRepository;
+
+public interface ProjectRepository extends GenericRepository<Project, Long> {
+}

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/resources/controllers/ProjectController.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/resources/controllers/ProjectController.java
@@ -1,0 +1,94 @@
+package br.com.edu.alunos.utfpr.protrack.resources.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.edu.alunos.utfpr.protrack.application.services.ProjectService;
+import br.com.edu.alunos.utfpr.protrack.domain.dtos.project.CreateProjectDTO;
+import br.com.edu.alunos.utfpr.protrack.domain.dtos.project.UpdateProjectDTO;
+import br.com.edu.alunos.utfpr.protrack.domain.exceptions.FailedToCreateProjectException;
+import br.com.edu.alunos.utfpr.protrack.domain.exceptions.NotFoundException;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Project;
+import br.com.edu.alunos.utfpr.protrack.resources.responses.ProjectResponse;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(final ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ProjectResponse> create(@RequestBody @Valid final CreateProjectDTO dto) {
+        try {
+            final Project created = projectService.create(dto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created.toResponse());
+        } catch (final NotFoundException | FailedToCreateProjectException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProjectResponse>> getAll() {
+        final List<ProjectResponse> responses = new ArrayList<>();
+        projectService.getAll().forEach(projectResponse -> responses.add(projectResponse.toResponse()));
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProjectResponse> getById(@PathVariable final Long id) {
+        try {
+            final Project project = projectService.getById(id);
+            return ResponseEntity.ok(project.toResponse());
+        } catch (final NotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProjectResponse> update(@PathVariable final Long id, @RequestBody @Valid final UpdateProjectDTO dto) {
+        try {
+            final UpdateProjectDTO withId = new UpdateProjectDTO(id, dto.name(), dto.description(), dto.clientId(),
+                    dto.teamId(), dto.startDate(), dto.endDate());
+            final Project updated = projectService.update(withId);
+            return ResponseEntity.ok(updated.toResponse());
+        } catch (final NotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable final Long id) {
+        try {
+            projectService.delete(id);
+            return ResponseEntity.noContent().build();
+        } catch (final NotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping("/{id}/progress")
+    public ResponseEntity<Integer> getProgress(@PathVariable final Long id) {
+        try {
+            final Project project = projectService.getById(id);
+            return ResponseEntity.ok(project.calculateProgress());
+        } catch (final NotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/br/com/edu/alunos/utfpr/protrack/resources/responses/ProjectResponse.java
+++ b/src/main/java/br/com/edu/alunos/utfpr/protrack/resources/responses/ProjectResponse.java
@@ -1,0 +1,19 @@
+package br.com.edu.alunos.utfpr.protrack.resources.responses;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class ProjectResponse {
+    private String name;
+    private String description;
+    private Long clientId;
+    private Long teamId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/test/java/br/com/edu/alunos/utfpr/protrack/application/services/ProjectServiceTest.java
+++ b/src/test/java/br/com/edu/alunos/utfpr/protrack/application/services/ProjectServiceTest.java
@@ -1,0 +1,267 @@
+package br.com.edu.alunos.utfpr.protrack.application.services;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import br.com.edu.alunos.utfpr.protrack.domain.dtos.project.CreateProjectDTO;
+import br.com.edu.alunos.utfpr.protrack.domain.dtos.project.UpdateProjectDTO;
+import br.com.edu.alunos.utfpr.protrack.domain.exceptions.FailedToCreateProjectException;
+import br.com.edu.alunos.utfpr.protrack.domain.exceptions.NotFoundException;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Client;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Project;
+import br.com.edu.alunos.utfpr.protrack.domain.models.Team;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.ClientRepository;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.ProjectRepository;
+import br.com.edu.alunos.utfpr.protrack.infrastructure.repositories.TeamRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private ClientRepository clientRepository;
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @DisplayName("O método 'create' deve criar um projeto com sucesso")
+    @Nested
+    class Method_create {
+
+        @Test
+        @DisplayName("deve criar projeto quando dados válidos")
+        void shouldCreateProject() throws FailedToCreateProjectException {
+            final CreateProjectDTO dto = new CreateProjectDTO("Proj A", "Desc A", 1L, 2L, LocalDate.of(2025, 1, 1),
+                    LocalDate.of(2025, 12, 31));
+            final Client client = new Client();
+            client.setId(1L);
+            final Team team = new Team();
+            team.setId(2L);
+            when(clientRepository.findById(1L)).thenReturn(Optional.of(client));
+            when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
+            when(projectRepository.save(any(Project.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            final Project project = projectService.create(dto);
+
+            verify(clientRepository, times(1)).findById(1L);
+            verify(teamRepository, times(1)).findById(2L);
+            verify(projectRepository, times(1)).save(any(Project.class));
+            assertNotNull(project);
+            assertEquals("Proj A", project.getName());
+            assertEquals(client, project.getClient());
+            assertEquals(team, project.getTeam());
+            assertEquals(dto.startDate(), project.getStartDate());
+            assertEquals(dto.endDate(), project.getEndDate());
+        }
+
+        @Test
+        @DisplayName("deve lançar NotFoundException quando client não existir")
+        void shouldThrowNotFoundWhenClientMissing() {
+            final CreateProjectDTO dto = new CreateProjectDTO("P", "D", 1L, 2L, LocalDate.now(), LocalDate.now());
+            when(clientRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> projectService.create(dto));
+            verify(clientRepository, times(1)).findById(1L);
+            verifyNoMoreInteractions(clientRepository);
+            verifyNoInteractions(teamRepository, projectRepository);
+        }
+
+        @Test
+        @DisplayName("deve lançar NotFoundException quando team não existir")
+        void shouldThrowNotFoundWhenTeamMissing() {
+            final CreateProjectDTO dto = new CreateProjectDTO("P", "D", 1L, 2L, LocalDate.now(), LocalDate.now());
+            final Client client = new Client();
+            client.setId(1L);
+            when(clientRepository.findById(1L)).thenReturn(Optional.of(client));
+            when(teamRepository.findById(2L)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> projectService.create(dto));
+            verify(clientRepository).findById(1L);
+            verify(teamRepository).findById(2L);
+            verifyNoInteractions(projectRepository);
+        }
+
+        @Test
+        @DisplayName("deve lançar FailedToCreateProjectException quando save falhar")
+        void shouldThrowFailedWhenRepoFails() {
+            final CreateProjectDTO dto = new CreateProjectDTO("P", "D", 1L, 2L, LocalDate.now(), LocalDate.now());
+            final Client client = new Client();
+            client.setId(1L);
+            final Team team = new Team();
+            team.setId(2L);
+            when(clientRepository.findById(1L)).thenReturn(Optional.of(client));
+            when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
+            when(projectRepository.save(any(Project.class))).thenThrow(new RuntimeException());
+
+            assertThrows(FailedToCreateProjectException.class, () -> projectService.create(dto));
+            verify(projectRepository).save(any(Project.class));
+        }
+    }
+
+    @DisplayName("O método 'update' deve atualizar um projeto")
+    @Nested
+    class Method_update {
+
+        @Test
+        @DisplayName("deve atualizar quando dados válidos")
+        void shouldUpdateProject() {
+            final UpdateProjectDTO dto = new UpdateProjectDTO(1L, "New Name", "New Desc", 3L, 4L, LocalDate.of(2025, 2, 1),
+                    LocalDate.of(2025, 11, 30));
+            final Project existing = new Project();
+            existing.setId(1L);
+            when(projectRepository.findById(1L)).thenReturn(Optional.of(existing));
+            final Client client = new Client();
+            client.setId(3L);
+            final Team team = new Team();
+            team.setId(4L);
+            when(clientRepository.findById(3L)).thenReturn(Optional.of(client));
+            when(teamRepository.findById(4L)).thenReturn(Optional.of(team));
+            when(projectRepository.save(any(Project.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            final Project updated = projectService.update(dto);
+
+            verify(projectRepository).findById(1L);
+            verify(projectRepository).save(existing);
+            assertEquals("New Name", updated.getName());
+            assertEquals("New Desc", updated.getDescription());
+            assertEquals(client, updated.getClient());
+            assertEquals(team, updated.getTeam());
+            assertEquals(dto.startDate(), updated.getStartDate());
+            assertEquals(dto.endDate(), updated.getEndDate());
+        }
+
+        @Test
+        @DisplayName("deve lançar NotFoundException quando projeto não existir")
+        void shouldThrowNotFoundWhenProjectMissing() {
+            final UpdateProjectDTO dto = new UpdateProjectDTO(1L, null, null, null, null, null, null);
+            when(projectRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> projectService.update(dto));
+            verify(projectRepository).findById(1L);
+            verifyNoMoreInteractions(projectRepository);
+        }
+
+        @Test
+        @DisplayName("deve lançar NotFoundException quando client fornecido não existir")
+        void shouldThrowNotFoundWhenClientMissingOnUpdate() {
+            final UpdateProjectDTO dto = new UpdateProjectDTO(1L, null, null, 5L, null, null, null);
+            final Project existing = new Project();
+            existing.setId(1L);
+            when(projectRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(clientRepository.findById(5L)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> projectService.update(dto));
+            verify(clientRepository).findById(5L);
+        }
+
+        @Test
+        @DisplayName("deve lançar NotFoundException quando team fornecido não existir")
+        void shouldThrowNotFoundWhenTeamMissingOnUpdate() {
+            final UpdateProjectDTO dto = new UpdateProjectDTO(1L, null, null, null, 6L, null, null);
+            final Project existing = new Project();
+            existing.setId(1L);
+            when(projectRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(teamRepository.findById(6L)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> projectService.update(dto));
+            verify(teamRepository).findById(6L);
+        }
+    }
+
+    @DisplayName("O método 'delete' deve remover um projeto")
+    @Nested
+    class Method_delete {
+
+        @Test
+        @DisplayName("deve deletar quando existir")
+        void shouldDeleteProject() {
+            when(projectRepository.findById(2L)).thenReturn(Optional.of(new Project()));
+
+            projectService.delete(2L);
+
+            verify(projectRepository).deleteById(2L);
+        }
+
+        @Test
+        @DisplayName("deve lançar NotFoundException quando não existir")
+        void shouldThrowNotFoundWhenDeletingMissing() {
+            when(projectRepository.findById(2L)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () -> projectService.delete(2L));
+            verify(projectRepository, never()).deleteById(anyLong());
+        }
+    }
+
+    @DisplayName("O método 'getById' deve retornar um projeto")
+    @Nested
+    class Method_getById {
+
+        @Test
+        @DisplayName("deve retornar quando existir")
+        void shouldGetById() {
+            final Project p = new Project();
+            p.setId(3L);
+            when(projectRepository.findById(3L)).thenReturn(Optional.of(p));
+
+            final Project result = projectService.getById(3L);
+
+            verify(projectRepository).findById(3L);
+            assertEquals(p, result);
+        }
+
+        @Test
+        @DisplayName("deve lançar NotFoundException quando não existir")
+        void shouldThrowNotFoundWhenGetMissing() {
+            when(projectRepository.findById(3L)).thenReturn(Optional.empty());
+            assertThrows(NotFoundException.class, () -> projectService.getById(3L));
+        }
+    }
+
+    @DisplayName("O método 'getAll' deve listar todos os projetos")
+    @Nested
+    class Method_getAll {
+
+        @Test
+        @DisplayName("deve retornar lista quando houver projetos")
+        void shouldListAll() {
+            when(projectRepository.findAll()).thenReturn(List.of(new Project(), new Project()));
+
+            final List<Project> list = projectService.getAll();
+
+            verify(projectRepository).findAll();
+            assertFalse(list.isEmpty());
+        }
+
+        @Test
+        @DisplayName("deve propagar exceção quando findAll falhar")
+        void shouldThrowWhenFindAllFails() {
+            when(projectRepository.findAll()).thenThrow(new RuntimeException());
+            assertThrows(RuntimeException.class, () -> projectService.getAll());
+        }
+    }
+}


### PR DESCRIPTION
## O que foi feito?
Implementado serviço de CRUD para a entidade de Projects.

## Como testar?
Executar as ações de CRUD para a entidade Projects em `{{urlBase}}/projects`.